### PR TITLE
Enhance Products page with genre filtering via query param and dropdo…

### DIFF
--- a/apps/manga-market-web/src/app/remote-entry/components/homecategories/homecategories.component.html
+++ b/apps/manga-market-web/src/app/remote-entry/components/homecategories/homecategories.component.html
@@ -14,6 +14,7 @@
   }@else {
   <lib-ui-carousel
     [items]="myCategories()"
+    (categorySelected)="onCategoryClick($event)"
     [templateType]="'category'"
     [numVisible]="5"
     [numScroll]="1"

--- a/apps/manga-market-web/src/app/remote-entry/components/homecategories/homecategories.component.ts
+++ b/apps/manga-market-web/src/app/remote-entry/components/homecategories/homecategories.component.ts
@@ -3,6 +3,8 @@ import { CommonModule } from '@angular/common';
 import { UiCarouselComponent } from '@mangamarket/manga-market-sharedLib';
 import { GenreStore } from '../../../stores/genre.store';
 import { ProgressSpinner } from 'primeng/progressspinner';
+import { Router } from '@angular/router';
+import { Genre } from '@prisma/client';
 
 @Component({
   selector: 'app-homecategories',
@@ -12,7 +14,12 @@ import { ProgressSpinner } from 'primeng/progressspinner';
 })
 export class HomecategoriesComponent {
   private readonly genreStore = inject(GenreStore);
-
+  private readonly router = inject(Router);
   readonly myCategories = computed(() => this.genreStore.genres());
   readonly loading = computed(() => this.genreStore.loading());
+  onCategoryClick(category: Genre) {
+    this.router.navigate(['/mangas'], {
+      queryParams: { genreId: category.id },
+    });
+  }
 }

--- a/apps/manga-market-web/src/app/remote-entry/components/products/products.component.ts
+++ b/apps/manga-market-web/src/app/remote-entry/components/products/products.component.ts
@@ -15,6 +15,7 @@ import {
   ProductCardComponent,
   SectionLoaderComponent,
 } from '@mangamarket/manga-market-sharedLib';
+import { ActivatedRoute } from '@angular/router';
 @Component({
   selector: 'app-products',
   imports: [
@@ -32,6 +33,7 @@ import {
 export class ProductsComponent implements OnInit {
   private readonly genreStore = inject(GenreStore);
   private readonly productStore = inject(ProductStore);
+  private readonly route = inject(ActivatedRoute);
   formGroup!: FormGroup;
   genres!: Genre[];
   selectedGenreId = signal<string | undefined>(undefined);
@@ -48,7 +50,25 @@ export class ProductsComponent implements OnInit {
 
   ngOnInit(): void {
     this.genreStore.loadGenres();
-    this.productStore.loadAllProducts();
+
+    const genreIdFromUrl = this.route.snapshot.queryParamMap.get('genreId');
+    if (genreIdFromUrl) {
+      setTimeout(() => {
+        const matched = this.genreStore
+          .genres()
+          .find((g) => g.id === genreIdFromUrl);
+        if (matched) {
+          this.formGroup.get('selectedGenre')?.setValue(matched);
+          this.selectedGenreId.set(matched.id);
+          this.productStore.loadAllProducts(matched.id);
+        } else {
+          this.productStore.loadAllProducts();
+        }
+      }, 200);
+    } else {
+      this.productStore.loadAllProducts();
+    }
+
     this.formGroup = new FormGroup({
       selectedGenre: new FormControl<Genre | null>(null),
     });

--- a/libs/manga-market-sharedLib/src/lib/ui-carousel/ui-carousel.component.html
+++ b/libs/manga-market-sharedLib/src/lib/ui-carousel/ui-carousel.component.html
@@ -34,6 +34,10 @@
     <div
       *ngIf="templateType === 'category'"
       class="category-item w-[120px] h-[120px] bg-gray-900 text-[#a3ffd4] flex items-center justify-center rounded-xl shadow-lg cursor-pointer transition-all duration-300 hover:scale-1 hover:shadow-xl hover:border hover:border-[#a3ffd4] sm:mx-2 mx-1"
+      (click)="handleCategoryClick(item)"
+      (keyup.enter)="handleCategoryClick(item)"
+      tabindex="0"
+      role="button"
     >
       <div
         class="md:text-base text-[12px] font-semibold text-center sm:px-4 p-0"

--- a/libs/manga-market-sharedLib/src/lib/ui-carousel/ui-carousel.component.ts
+++ b/libs/manga-market-sharedLib/src/lib/ui-carousel/ui-carousel.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { CarouselModule } from 'primeng/carousel';
 import { ButtonModule } from 'primeng/button';
@@ -27,6 +27,7 @@ export class UiCarouselComponent {
   @Input() responsiveOptions: any[] | null = null;
   @Input() orientation: 'horizontal' | 'vertical' = 'horizontal';
   @Input() verticalHeight = '330px';
+  @Output() categorySelected=new EventEmitter<any>();
 
   defaultResponsive: any[] = [
     {
@@ -45,4 +46,8 @@ export class UiCarouselComponent {
       numScroll: 1,
     },
   ];
+
+   handleCategoryClick(category: any) {
+    this.categorySelected.emit(category);
+  }
 }


### PR DESCRIPTION
- Integrated genre filtering logic using `ActivatedRoute` to detect `genreId` in the URL.
- Auto-selects the matching genre in the dropdown when routed from homepage.
- Keeps default behavior of loading all products intact when no genre is specified.
- Refactored scroll loading to support pagination based on selected genre.
- Ensured that genre dropdown and selected filter stay in sync with store updates.